### PR TITLE
DADA2 memory optimizations and bugfixes

### DIFF
--- a/bin/dada_overlaps.R
+++ b/bin/dada_overlaps.R
@@ -176,13 +176,13 @@ seqtab.nochim.df <- seqtab.nochim.df %>%
   mutate(sampleID = str_remove_all(sample, pat.sampleID)) %>%
   select(sampleID, locus, asv, reads)
 
-allele_sequences <- seqtab.nochim.df |>
-  dplyr::select(locus, asv) |>
-  dplyr::distinct() |>
-  dplyr::group_by(locus) |>
-  dplyr::mutate(allele = seq(1, dplyr::n())) |>
-  dplyr::ungroup() |>
-  dplyr::mutate(allele = paste0(locus, ".", allele)) |>
+allele_sequences <- seqtab.nochim.df %>%
+  dplyr::select(locus, asv) %>%
+  dplyr::distinct() %>%
+  dplyr::group_by(locus) %>%
+  dplyr::mutate(allele = seq(1, dplyr::n())) %>%
+  dplyr::ungroup() %>%
+  dplyr::mutate(allele = paste0(locus, ".", allele)) %>%
   dplyr::rename(sequence = asv)
 
 allele.data = seqtab.nochim.df %>%

--- a/bin/dada_overlaps.R
+++ b/bin/dada_overlaps.R
@@ -56,61 +56,60 @@ names(filtFs) <- sample.names
 names(filtRs) <- sample.names
 # 
 
-out <- filterAndTrim(fnFs, filtFs, fnRs, filtRs,
-              maxN=0, maxEE=c(args$maxEE, args$maxEE), truncQ=c(5,5), rm.phix=TRUE,
-              compress=TRUE, multithread=TRUE,
-              trimRight = c(0,0),trimLeft = 1, minLen=75,matchIDs=TRUE) 
+out <- filterAndTrim(
+  fnFs, filtFs, fnRs, filtRs,
+  maxN = 0, maxEE = c(args$maxEE, args$maxEE), truncQ = c(5, 5), rm.phix = TRUE,
+  compress = TRUE, multithread = args$cores,  
+  trimRight = c(0, 0), trimLeft = 1, minLen = 75, matchIDs = TRUE
+) 
 head(out)
 
+filtered_Fs <- filtFs[out[, 2] > 0]
+filtered_Rs <- filtRs[out[, 2] > 0]
 
-errF <- learnErrors(filtFs[out[,2]>0], multithread=TRUE,MAX_CONSIST=10,randomize=TRUE)
-errR <- learnErrors(filtRs[out[,2]>0], multithread=TRUE,MAX_CONSIST=10,randomize=TRUE)
-
-derepFs <- derepFastq(filtFs[out[,2]>0], verbose = TRUE)
-derepRs <- derepFastq(filtRs[out[,2]>0], verbose = TRUE)
+errF <- learnErrors(filtered_Fs, multithread = args$cores, MAX_CONSIST = 10, randomize = TRUE)
+errR <- learnErrors(filtered_Rs, multithread = args$cores, MAX_CONSIST = 10, randomize  =TRUE)
 
 
-pool=switch(
+pool <- switch(
   args$pool,
   "true" = TRUE,
   "false" = FALSE,
   "pseudo" = "pseudo"
 )
 
-dadaFs <- dada(derepFs, err=errF, selfConsist=args$self_consist, multithread=args$cores, verbose=FALSE, pool=pool, BAND_SIZE=args$band_size, OMEGA_A=args$omega_a)
-dadaRs <- dada(derepRs, err=errR, selfConsist=args$self_consist, multithread=args$cores, verbose=FALSE, pool=pool, BAND_SIZE=args$band_size, OMEGA_A=args$omega_a)
+dadaFs <- dada(filtered_Fs, err = errF, selfConsist = args$self_consist, multithread = args$cores, verbose = FALSE, pool = pool, BAND_SIZE = args$band_size, OMEGA_A = args$omega_a)
+dadaRs <- dada(filtered_Rs, err = errR, selfConsist = args$self_consist, multithread = args$cores, verbose = FALSE, pool = pool, BAND_SIZE = args$band_size, OMEGA_A = args$omega_a)
 
-if(args$concat_non_overlaps){
-  
-
+if (args$concat_non_overlaps) {
   amplicon.info = data.frame(
     names = sapply(strsplit(names(dadaFs),"_trimmed"),"[",1)
   )
 
   amplicon.info <- amplicon.info %>%
-    mutate(names=sapply(str_split(names,'_S(\\d+)'),head,1)) %>% 
-    mutate(amplicon=unlist(lapply(str_split(names,'_'), function(x) { paste(x[1:3], collapse = "_") }))) %>%
-    inner_join(read.table(args$ampliconFILE,header=T) %>% 
-             select(amplicon, ampInsert_length), by = c("amplicon")) %>%
+    mutate(names = sapply(str_split(names,'_S(\\d+)'),head,1)) %>% 
+    mutate(amplicon = unlist(lapply(str_split(names,'_'), function(x) { paste(x[1:3], collapse = "_") }))) %>%
+    inner_join(
+      read.table(args$ampliconFILE,header=T) %>% 
+        select(amplicon, ampInsert_length), by = c("amplicon")
+    ) %>%
     # mutate(Pool=sapply(str_split(Amplicon,'-'),tail,1)) %>% 
     # mutate(Amplicon=unlist(lapply(str_split(Amplicon,'-'), function(x) { paste(x[1:2], collapse = "-") })))
-
     select(amplicon, ampInsert_length) %>%
     mutate(
       sum.mean.length.reads = sapply(sapply(unlist(lapply(dadaFs,"[","sequence"),recursive = F),nchar),mean)+
         sapply(sapply(unlist(lapply(dadaRs,"[","sequence"),recursive = F),nchar),mean)
     )
 
-  rownames(amplicon.info)=names(dadaFs)
-
+  rownames(amplicon.info) <- names(dadaFs)
   
 #  sample.names.no.overlap = sample.names[as.numeric(sapply(strsplit(sample.names ,"-"),"[",3)) - as.numeric(sapply(strsplit(sample.names ,"-"),"[",2))>275]
 #  sample.names.overlap = sample.names[as.numeric(sapply(strsplit(sample.names ,"-"),"[",3)) - as.numeric(sapply(strsplit(sample.names ,"-"),"[",2))<276]
   
   mergers.overlap = mergePairs(dadaFs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)<sum.mean.length.reads))],
-                               derepFs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)<sum.mean.length.reads))], 
+                               filtered_Fs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)<sum.mean.length.reads))], 
                                dadaRs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)<sum.mean.length.reads))], 
-                               derepRs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)<sum.mean.length.reads))], 
+                               filtered_Rs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)<sum.mean.length.reads))], 
                                verbose=TRUE, 
                                justConcatenate=FALSE, 
                                trimOverhang = TRUE,
@@ -118,9 +117,9 @@ if(args$concat_non_overlaps){
                                maxMismatch=1)
   
   mergers.no.overlap = mergePairs(dadaFs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)>=sum.mean.length.reads))],
-                                  derepFs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)>=sum.mean.length.reads))], 
+                                  filtered_Fs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)>=sum.mean.length.reads))], 
                                   dadaRs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)>=sum.mean.length.reads))], 
-                                  derepRs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)>=sum.mean.length.reads))], 
+                                  filtered_Rs[names(dadaFs) %in% rownames(amplicon.info %>% filter((ampInsert_length+10)>=sum.mean.length.reads))], 
                                   verbose=TRUE, 
                                   justConcatenate=TRUE)
   
@@ -133,67 +132,65 @@ if(args$concat_non_overlaps){
     mergers.no.overlap = list(mergers.no.overlap)
   }
 
-
   mergers = c(mergers.overlap,mergers.no.overlap)[names(dadaFs)]
   save(file = 'mergers.rda', mergers, mergers.overlap, mergers.no.overlap, amplicon.info, dadaFs, dadaRs, args)
 
-}else{
-    mergers=  mergePairs(dadaFs,
-                         derepFs, 
+} else {
+    mergers = mergePairs(dadaFs,
+                         filtered_Fs, 
                          dadaRs, 
-                         derepRs, 
-                         verbose=TRUE, 
-                         justConcatenate=FALSE, 
+                         filtered_Rs, 
+                         verbose = TRUE, 
+                         justConcatenate = FALSE, 
                          trimOverhang = TRUE,
-                         minOverlap=10,
-                         maxMismatch=1)
+                         minOverlap = 10,
+                         maxMismatch = 1)
   }
 
+rm(dadaFs, dadaRs)
 
 seqtab <- makeSequenceTable(mergers)
-seqtab.nochim <- removeBimeraDenovo(seqtab, method="consensus", multithread=TRUE, verbose=TRUE)
+seqtab.nochim <- removeBimeraDenovo(seqtab, method = "consensus", multithread = TRUE, verbose = TRUE)
 
 ### Create clusters output file with quality control
 
-seqtab.nochim.df = as.data.frame(seqtab.nochim)
-seqtab.nochim.df$sample = rownames(seqtab.nochim)
-seqtab.nochim.df[seqtab.nochim.df==0]=NA
+seqtab.nochim.df <- as.data.frame(seqtab.nochim)
+seqtab.nochim.df$sample <- rownames(seqtab.nochim)
+
+rm(seqtab.nochim)
+
+seqtab.nochim.df[seqtab.nochim.df == 0] = NA
 
 amplicon.table=read.table(args$ampliconFILE, header = TRUE, sep = "\t")
 
 # find amplicons (use to select)
-pat=paste(amplicon.table$amplicon, collapse="|") # find amplicons specified in amplicon table
+pat = paste(amplicon.table$amplicon, collapse = "|") # find amplicons specified in amplicon table
 
 # create regex to extract sampleID (to be used with remove)
-pat.sampleID=paste(sprintf("^%s_", amplicon.table$amplicon), collapse="|") # find amplicons specified in amplicon table (with _)
-pat.sampleID=paste(c(pat.sampleID, "_trimmed_merged.fastq.gz$"),collapse="|")  # remove _trimmed from end
+pat.sampleID = paste(sprintf("^%s_", amplicon.table$amplicon), collapse = "|") # find amplicons specified in amplicon table (with _)
+pat.sampleID = paste(c(pat.sampleID, "_trimmed_merged.fastq.gz$"), collapse = "|")  # remove _trimmed from end
 
-seqtab.nochim.df = seqtab.nochim.df %>%
-  pivot_longer(cols = seq(1,ncol(seqtab.nochim)),names_to = "asv",values_to = "reads",values_drop_na=TRUE) %>%
+seqtab.nochim.df <- seqtab.nochim.df %>%
+  pivot_longer(cols = seq(1, ncol(seqtab.nochim.df) - 1), names_to = "asv", values_to = "reads", values_drop_na = TRUE) %>%
   mutate(locus = str_extract(sample, pat)) %>%
   mutate(sampleID = str_remove_all(sample, pat.sampleID)) %>%
-  select(sampleID,locus,asv,reads)
+  select(sampleID, locus, asv, reads)
 
-temp = seqtab.nochim.df %>% select(locus,asv) %>% distinct()
-loci =unique(temp$locus)
-k=1
-allele.sequences = data.frame(locus = seq(1,nrow(temp)),allele = seq(1,nrow(temp)),sequence = seq(1,nrow(temp)))
-for(i in seq(1,length(loci))){
-  temp2 = temp %>% filter(locus==loci[i])
-  for(j in seq(1,nrow(temp2))){
-    allele.sequences$locus[k+j-1] = loci[i]
-    allele.sequences$allele[k+j-1] = paste0(loci[i],".",j)
-    allele.sequences$sequence[k+j-1] = temp2$asv[j]
-  }
-  k=k+nrow(temp2)
-}
+allele_sequences <- seqtab.nochim.df |>
+  dplyr::select(locus, asv) |>
+  dplyr::distinct() |>
+  dplyr::group_by(locus) |>
+  dplyr::mutate(allele = seq(1, dplyr::n())) |>
+  dplyr::ungroup() |>
+  dplyr::mutate(allele = paste0(locus, ".", allele)) |>
+  dplyr::rename(sequence = asv)
 
 allele.data = seqtab.nochim.df %>%
   mutate(sampleID = str_remove_all(sampleID, pat = "_trimmed")) %>%
-  left_join(allele.sequences %>% select(-locus),by=c("asv"="sequence")) %>%
-  group_by(sampleID,locus) %>%
-  mutate(norm.reads.locus = reads/sum(reads))%>%
+  left_join(allele_sequences %>% select(-locus), by = c("asv" = "sequence")) %>%
+  group_by(sampleID, locus) %>%
+  mutate(norm.reads.locus = reads / sum(reads)) %>%
   mutate(n.alleles = n()) %>%
   ungroup()
 
-write.table(allele.data,file="dada2.clusters.txt",quote=F,sep="\t",col.names=T,row.names=F)
+write.table(allele.data, file = "dada2.clusters.txt", quote = FALSE, sep = "\t", col.names = TRUE, row.names = FALSE)


### PR DESCRIPTION
Functionally everything is the same, this commit reduces peak memory usage and improves readability. Outputs should not change.
- No longer preload dereplicated files, reducing peak memory usage. DADA2 automatically dereplicates files as needed
- Fix function calls to respect args$cores input
- remove large objects from memory as they are finished being used, reducing peak memory usage especially at end of script
- rewrite the unique allele merging function to be more readable